### PR TITLE
renovate: pin GitHub Action digests to semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["helpers:pinGitHubActionDigestsToSemver"],
   "dependencyDashboard": true,
   "pre-commit": { "enabled": true },
   "automerge": true,


### PR DESCRIPTION
## Summary
- Actions were already SHA-pinned but with no version comment/extends configured, so digest bumps showed with no visible version or changelog.
- All actions in use (`actions/checkout`, `docker/setup-buildx-action`, `docker/login-action`, `docker/metadata-action`, `docker/build-push-action`) publish full semver release tags, so switch `renovate.json` to `helpers:pinGitHubActionDigestsToSemver`.

## Test plan
- [x] Validated `renovate.json` is valid JSON
- [ ] Confirm next Renovate run proposes real semver-labeled digest updates